### PR TITLE
Add name management functionality for Characters and Pets

### DIFF
--- a/templates/private/admin_base.html
+++ b/templates/private/admin_base.html
@@ -1,0 +1,18 @@
+{% extends "bootstrap/base.html" %}
+
+{% block navbar %}
+<nav class="navbar navbar-default">
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <a class="navbar-brand" href="{{ url_for('dashboard') }}">Dashboard</a>
+    </div>
+    <ul class="nav navbar-nav">
+        <a class="navbar-brand" href="{{ url_for('approve_names') }}">Name Approval</a>
+    </ul>
+    <ul class="nav navbar-nav" style="float: right">
+      <li class="active"><a href="#">Welcome {{ current_user.username }}!</a></li>
+      <li><a href="{{ url_for('logout') }}">Logout</a></li>
+    </ul>
+  </div>
+</nav>
+{% endblock navbar %}}

--- a/templates/private/approve_names.html
+++ b/templates/private/approve_names.html
@@ -96,7 +96,7 @@ const approvalButtons = document.querySelectorAll('.approvalButton');
 
 for (const button of approvalButtons) {
     button.addEventListener('click', (event) => {
-        $("html").load("{{ url_for('approve_names') }}", {
+        $("body").load("{{ url_for('approve_names') }}", {
             char_id: parseInt(event.target.dataset.id),
             pending_name: event.target.dataset.pending_name,
             approved: 1,

--- a/templates/private/approve_names.html
+++ b/templates/private/approve_names.html
@@ -1,21 +1,5 @@
-{% extends "bootstrap/base.html" %}
+{% extends "private/admin_base.html" %}
 {% block title %}Name Approval{% endblock %}
-
-{% block navbar %}
-<nav class="navbar navbar-default">
-  <div class="container-fluid">
-    <div class="navbar-header">
-      <a class="navbar-brand" href="{{ url_for('dashboard') }}">Dashboard</a>
-    </div>
-    <ul class="nav navbar-nav">
-    </ul>
-    <ul class="nav navbar-nav" style="float: right">
-      <li class="active"><a href="#">Welcome {{ current_user.username }}!</a></li>
-      <li><a href="{{ url_for('logout') }}">Logout</a></li>
-    </ul>
-  </div>
-</nav>
-{% endblock navbar %}}
 
 {% block content %}
 {# LOGO #}
@@ -58,8 +42,8 @@
         </div>
     {% endif %}
 
-    {# If the keys value is set, create a list for each key in keys #}
     {% if names %}
+    <h3>Character Names</h3>
     <table class="table table-striped">
         <tr>
             <th>Character ID</th>
@@ -81,6 +65,25 @@
         {% endfor %}
     </table>
     {% endif %}
+    {% if pet_names %}
+    <h3>Pet Names</h3>
+    <table class="table table-striped">
+        <tr>
+            <th>Pet ID</th>
+            <th>Current Name</th>
+            <th>Approve?</th>
+            <th>Reject?</th>
+        </tr>
+        {% for name in pet_names %}
+        <tr>
+            <td>{{ name.id }}</td>
+            <td>{{ name.pet_name }}</td>
+            <td><button class="btn btn-primary approvalPetButton" data-id="{{ name.id }}" data-pending_name="{{ name.pet_name }}">Approve</button></td>
+            <td><button class="btn btn-warning rejectPetButton" data-id="{{ name.id }}" data-pending_name="{{ name.pet_name }}">Reject</button></td>
+        </tr>
+        {% endfor %}
+    </table>
+    {% endif %}
     </div>
     <div class="col-lg-3">
     </div>
@@ -92,24 +95,40 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 <script>
 
-const approvalButtons = document.querySelectorAll('.approvalButton');
-
-for (const button of approvalButtons) {
+for (const button of document.querySelectorAll('.approvalButton')) {
     button.addEventListener('click', (event) => {
         $("body").load("{{ url_for('approve_names') }}", {
-            char_id: parseInt(event.target.dataset.id),
+            char_id: event.target.dataset.id,
             pending_name: event.target.dataset.pending_name,
             approved: 1,
         });
     });
 }
 
-const rejectButtons = document.querySelectorAll('.rejectButton');
-
-for (const button of rejectButtons) {
+for (const button of document.querySelectorAll('.rejectButton')) {
     button.addEventListener('click', (event) => {
         $("body").load("{{ url_for('approve_names') }}", {
-            char_id: parseInt(event.target.dataset.id),
+            char_id: event.target.dataset.id,
+            pending_name: event.target.dataset.pending_name,
+            approved: 0,
+        });
+    });
+}
+
+for (const button of document.querySelectorAll('.approvalPetButton')) {
+    button.addEventListener('click', (event) => {
+        $("body").load("{{ url_for('approve_names') }}", {
+            pet_id: event.target.dataset.id,
+            pending_name: event.target.dataset.pending_name,
+            approved: 1,
+        });
+    });
+}
+
+for (const button of document.querySelectorAll('.rejectPetButton')) {
+    button.addEventListener('click', (event) => {
+        $("body").load("{{ url_for('approve_names') }}", {
+            pet_id: event.target.dataset.id,
             pending_name: event.target.dataset.pending_name,
             approved: 0,
         });

--- a/templates/private/approve_names.html
+++ b/templates/private/approve_names.html
@@ -1,0 +1,121 @@
+{% extends "bootstrap/base.html" %}
+{% block title %}Name Approval{% endblock %}
+
+{% block navbar %}
+<nav class="navbar navbar-default">
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <a class="navbar-brand" href="{{ url_for('dashboard') }}">Dashboard</a>
+    </div>
+    <ul class="nav navbar-nav">
+    </ul>
+    <ul class="nav navbar-nav" style="float: right">
+      <li class="active"><a href="#">Welcome {{ current_user.username }}!</a></li>
+      <li><a href="{{ url_for('logout') }}">Logout</a></li>
+    </ul>
+  </div>
+</nav>
+{% endblock navbar %}}
+
+{% block content %}
+{# LOGO #}
+<div class="container" style="margin-top: 50px">
+
+    {# Display logo #}
+    <div style="margin-bottom: 50px">
+        <img
+                src="{{ url_for('static', filename=resources.LOGO) }}"
+                class="center-block img-responsive mx-auto d-block"
+                alt="Logo"
+                width="100"
+                height="100"
+        >
+    </div>
+
+</div>
+
+{# Key creation #}
+<div class="container">
+    <div class="text-center">
+        <h3>Name Approval</h3>
+    </div>
+
+    <div class="col-lg-3">
+    </div>
+    <div class="col-lg-6">
+
+    {# If the error value is set, display the error in red text #}
+    {% if error %}
+        <div class="alert alert-danger">
+            {{ error }}
+        </div>
+    {% endif %}
+
+    {# If the message value is set, display the message in green text #}
+    {% if message %}
+        <div class="alert alert-success">
+            {{ message }}
+        </div>
+    {% endif %}
+
+    {# If the keys value is set, create a list for each key in keys #}
+    {% if names %}
+    <table class="table table-striped">
+        <tr>
+            <th>Character ID</th>
+            <th>Account ID</th>
+            <th>Current Name</th>
+            <th>Custom Name</th>
+            <th>Approve?</th>
+            <th>Reject?</th>
+        </tr>
+        {% for name in names %}
+        <tr>
+            <td>{{ name.id }}</td>
+            <td>{{ name.account_id }}</td>
+            <td>{{ name.name }}</td>
+            <td>{{ name.pending_name }}</td>
+            <td><button class="btn btn-primary approvalButton" data-id="{{ name.id }}" data-pending_name="{{ name.pending_name }}">Approve</button></td>
+            <td><button class="btn btn-warning rejectButton" data-id="{{ name.id }}" data-pending_name="{{ name.pending_name }}">Reject</button></td>
+        </tr>
+        {% endfor %}
+    </table>
+    {% endif %}
+    </div>
+    <div class="col-lg-3">
+    </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+<script>
+
+const approvalButtons = document.querySelectorAll('.approvalButton');
+
+for (const button of approvalButtons) {
+    button.addEventListener('click', (event) => {
+        $("html").load("{{ url_for('approve_names') }}", {
+            char_id: parseInt(event.target.dataset.id),
+            pending_name: event.target.dataset.pending_name,
+            approved: 1,
+        });
+    });
+}
+
+const rejectButtons = document.querySelectorAll('.rejectButton');
+
+for (const button of rejectButtons) {
+    button.addEventListener('click', (event) => {
+        $("body").load("{{ url_for('approve_names') }}", {
+            char_id: parseInt(event.target.dataset.id),
+            pending_name: event.target.dataset.pending_name,
+            approved: 0,
+        });
+    });
+}
+
+</script>
+
+{% endblock %}

--- a/templates/private/dashboard.html
+++ b/templates/private/dashboard.html
@@ -1,21 +1,5 @@
-{% extends "bootstrap/base.html" %}
+{% extends "private/admin_base.html" %}
 {% block title %}Key Creation{% endblock %}
-
-{% block navbar %}
-<nav class="navbar navbar-default">
-  <div class="container-fluid">
-    <div class="navbar-header">
-      <a class="navbar-brand" href="{{ url_for('dashboard') }}">Dashboard</a>
-    </div>
-    <ul class="nav navbar-nav">
-    </ul>
-    <ul class="nav navbar-nav" style="float: right">
-      <li class="active"><a href="#">Welcome {{ current_user.username }}!</a></li>
-      <li><a href="{{ url_for('logout') }}">Logout</a></li>
-    </ul>
-  </div>
-</nav>
-{% endblock navbar %}}
 
 {% block content %}
 {# LOGO #}


### PR DESCRIPTION
The following PR adds the approve_names route, which pulls all names that are still pending, and allows a GM user to either approve or reject names, updating them in the DB.

- Adds approve_names template for viewing pending character and pet names
- Adds functionality to approve or reject names from the interface
- Adds approve_names get/post routes with appropriate functionality
- Moves the navbar into its own template to allow for less code duplication

Open question: Is this the correct way to do name approval? Does anything else need to happen for it to work correctly?

Fixes #2
Fixes #8 