### PR TITLE
Add button for copying activation link to clipboard

### DIFF
--- a/templates/private/dashboard.html
+++ b/templates/private/dashboard.html
@@ -1,6 +1,11 @@
 {% extends "bootstrap/base.html" %}
 {% block title %}Key Creation{% endblock %}
 
+{% block head %}
+    {{ super() }}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css">
+{% endblock %}
+
 {% block navbar %}
 <nav class="navbar navbar-default">
   <div class="container-fluid">
@@ -75,13 +80,16 @@
 
     {# If the keys value is set, create a list for each key in keys #}
     {% if keys %}
-        <div class="alert alert-success">
-            <ul>
-                {% for key in keys %}
-                    <li>{{ key }}</li>
-                {% endfor %}
-            </ul>
-        </div>
+        <ul class="list-group">
+            {% for key in keys %}
+                <li class="list-group-item list-group-item-success">
+                    <code>{{ key }}</code>
+                    <button type="button" class="btn btn-success" title="Copy activation link" data-clipboard-text="{{ url_for('account_creation', _external=True) }}/{{ key }}">
+                        <i class="bi bi-clipboard"></i>
+                    </button>
+                </li>
+            {% endfor %}
+        </ul>
     {% endif %}
     </div>
     <div class="col-lg-3">
@@ -115,6 +123,8 @@
 {% block scripts %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js@3.5.1/dist/chart.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+<!-- Used for copying activation links -->
+<script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.8/dist/clipboard.min.js"></script>
 
 <script>
 // Make a get request to the server to load the activity data
@@ -184,5 +194,7 @@ $.get("{{ url_for('activity_data', name='zone_play_time') }}", function(data) {
         }
     });
 });
+
+new ClipboardJS('.btn');
 </script>
 {% endblock scripts %}}


### PR DESCRIPTION
Adds a button for copying the activation link after having created play keys:

![Key generation screenshot](https://user-images.githubusercontent.com/11685886/147862042-3d03085c-8167-49fe-8dde-9cd9373ffc84.png)

Clicking the buttons copies the the absolute activation link, e.g. `http://localhost:5000/activate/JNNR-VP5Y-RZPP-R1IQ`, to the clipboard.
It does not look very good, and you do not get any visual feedback when clicking the button (in contrast to what you might be used to from the GitHub UI, or other websites), but it is at least functional. Any feedback is appreciated.