### PR TITLE
Only show legal agreement checkbox when agreement files exist

### DIFF
--- a/templates/private/dashboard.html
+++ b/templates/private/dashboard.html
@@ -63,7 +63,7 @@
         {# Key count input #}
         <div class="form-group">
             <label for="key_count">Generate keys</label>
-            <input type="number" class="form-control" name="key_count" placeholder="Enter number of keys...">
+            <input type="number" class="form-control" id="key_count" name="key_count" placeholder="Enter number of keys...">
             <small class="form-text text-muted">Number of keys to create.</small>
         </div>
         
@@ -85,7 +85,6 @@
     {% endif %}
     </div>
     <div class="col-lg-3">
-    </div>
     </div>
 </div>
 

--- a/templates/private/data_download.html
+++ b/templates/private/data_download.html
@@ -36,7 +36,7 @@
         {# Account Name input #}
         <div class="form-group">
             <label for="character_name">Character Name</label>
-            <input type="text" class="form-control" name="character_name" placeholder="Enter username...">
+            <input type="text" class="form-control" id="character_name" name="character_name" placeholder="Enter username...">
             <small class="form-text text-muted">Full character name.</small>
         </div>
 
@@ -47,7 +47,6 @@
     </form>
     </div>
     <div class="col-lg-3">
-    </div>
     </div>
 </div>
 {% endblock %}

--- a/templates/private/login.html
+++ b/templates/private/login.html
@@ -36,20 +36,20 @@
         {# Admin Username input #}
         <div class="form-group">
             <label for="account_name">Username</label>
-            <input type="text" class="form-control" name="account_name" placeholder="Enter username...">
+            <input type="text" class="form-control" id="account_name" name="account_name" placeholder="Enter username...">
         </div>
 
         {# Admin password input #}
         <div class="form-group">
             <label for="account_password">Password</label>
-            <input type="password" class="form-control" name="account_password" placeholder="Enter password...">
+            <input type="password" class="form-control" id="account_password" name="account_password" placeholder="Enter password...">
             <small class="form-text text-muted"></small>
         </div>
 
         {# Remember Me #}
         <div class="form-group">
             <label for="remember_me">Remember Me</label>
-            <input type="checkbox" class="form-control" name="remember_me">
+            <input type="checkbox" class="form-control" id="remember_me" name="remember_me">
             <small class="form-text text-muted"></small>
         </div>
         
@@ -71,7 +71,6 @@
     {% endif %}
     </div>
     <div class="col-lg-3">
-    </div>
     </div>
 </div>
 {% endblock %}

--- a/templates/public/account_creation.html
+++ b/templates/public/account_creation.html
@@ -36,28 +36,28 @@
         {# Play Key input #}
         <div class="form-group">
             <label for="play_key">Play Key</label>
-            <input type="text" class="form-control" name="play_key" aria-describedby="emailHelp" placeholder="AAAA-BBBB-CCCC-DDDD" value="{{ key }}">
+            <input type="text" class="form-control" id="play_key" name="play_key" aria-describedby="emailHelp" placeholder="AAAA-BBBB-CCCC-DDDD" value="{{ key }}">
             <small class="form-text text-muted">In the format: AAAA-BBBB-CCCC-DDDD</small>
         </div>
 
         {# Account Name input #}
         <div class="form-group">
             <label for="account_name">Username</label>
-            <input type="text" class="form-control" name="account_name" placeholder="Enter username...">
+            <input type="text" class="form-control" id="account_name" name="account_name" placeholder="Enter username...">
             <small class="form-text text-muted">Limited to a-z, A-Z, and 0-9. No spaces or special characters. Max 32 characters.</small>
         </div>
 
         {# Account Password input #}
         <div class="form-group">
             <label for="account_password">Password</label>
-            <input type="password" class="form-control" name="account_password" placeholder="Enter password...">
+            <input type="password" class="form-control" id="account_password" name="account_password" placeholder="Enter password...">
             <small class="form-text text-muted"></small>
         </div>
         
         {# Account Repeat Password input #}
         <div class="form-group">
             <label for="account_repeat_password">Repeat Password</label>
-            <input type="password" class="form-control" name="account_repeat_password" placeholder="Repeat password...">
+            <input type="password" class="form-control" id="account_repeat_password" name="account_repeat_password" placeholder="Repeat password...">
             <small class="form-text text-muted"></small>
         </div>
 
@@ -76,7 +76,6 @@
     </form>
     </div>
     <div class="col-lg-3">
-    </div>
     </div>
 </div>
 {% endblock %}

--- a/templates/public/account_creation.html
+++ b/templates/public/account_creation.html
@@ -62,12 +62,14 @@
         </div>
 
         {# Agree to the Privacy Policy and Terms of Service #}
-        <div class="form-group">
-            <label class="checkbox-inline">
-                <input type="checkbox" name="agree">
-                I agree to the <a href="{{ url_for('static', filename=resources.PRIVACY_POLICY) }}" target="_blank">Privacy Policy</a> and <a href="{{ url_for('static', filename=resources.TERMS_OF_USE) }}" target="_blank">Terms of Service</a>
-            </label>
-        </div>
+        {% if resources.requires_user_agreement %}
+            <div class="form-group">
+                <label class="checkbox-inline">
+                    <input type="checkbox" name="agree">
+                    I agree to the <a href="{{ url_for('static', filename=resources.PRIVACY_POLICY) }}" target="_blank">Privacy Policy</a> and <a href="{{ url_for('static', filename=resources.TERMS_OF_USE) }}" target="_blank">Terms of Service</a>
+                </label>
+            </div>
+        {% endif %}
         
         {# Submit button #}
         <div class="form-group">


### PR DESCRIPTION
Resolves #17

Currently it checks whether any of the legal agreement files are present and then requires agreement for both, even if one of them is missing. Whether that is acceptable depends on the use case you had in mind. Please let me know what you think this implementation.