### PR TITLE
Adding SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ PRIVACY_POLICY = 'policy/Privacy Policy.pdf'
 # Path to the terms of use users have to agree to
 TERMS_OF_USE = 'policy/Terms of Use.pdf'
 ```
+* Create SSL certificates
+```sh
+# Run the openssl command
+openssl req -x509 -newkey rsa:4096 -nodes -out cert.pem -keyout key.pem -days 365
+```
+
 * Run the application
 ```sh
 # Run the python application, with a given port number

--- a/app.py
+++ b/app.py
@@ -554,7 +554,7 @@ def run_app():
     # Setup Bootstrap
     Bootstrap(app)
 
-    app.run(host='0.0.0.0', port=5000)
+    app.run(host='0.0.0.0', port=5000, ssl_context=("cert.pem", "key.pem"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The current AccountManager handles passwords and usernames but still uses HTTP.
This change changes the webserver so it uses HTTPS instread wuth a self-signed certificate.

It adds some security to the webserver.